### PR TITLE
open all files as UTF-8

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -1,3 +1,4 @@
+import io
 import os
 from six.moves.urllib.request import urlopen, Request
 from six.moves.urllib.parse import unquote
@@ -24,14 +25,14 @@ class CheckLinks(pytest.File):
     """Check the links in a file"""
     def _html_from_html(self):
         """Return HTML from an HTML file"""
-        with open(str(self.fspath), encoding=_ENC) as f:
+        with io.open(str(self.fspath), encoding=_ENC) as f:
             return f.read()
     
     def _html_from_markdown(self):
         """Return HTML from a markdown file"""
         # FIXME: use commonmark or a pluggable engine
         from nbconvert.filters import markdown2html
-        with open(str(self.fspath), encoding=_ENC) as f:
+        with io.open(str(self.fspath), encoding=_ENC) as f:
             markdown = f.read()
         return markdown2html(markdown)
     

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -5,6 +5,8 @@ from six.moves.urllib.parse import unquote
 import html5lib
 import pytest
 
+_ENC = 'utf8'
+
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption('--check-links', action='store_true',
@@ -22,14 +24,14 @@ class CheckLinks(pytest.File):
     """Check the links in a file"""
     def _html_from_html(self):
         """Return HTML from an HTML file"""
-        with open(str(self.fspath)) as f:
+        with open(str(self.fspath), encoding=_ENC) as f:
             return f.read()
     
     def _html_from_markdown(self):
         """Return HTML from a markdown file"""
         # FIXME: use commonmark or a pluggable engine
         from nbconvert.filters import markdown2html
-        with open(str(self.fspath)) as f:
+        with open(str(self.fspath), encoding=_ENC) as f:
             markdown = f.read()
         return markdown2html(markdown)
     


### PR DESCRIPTION
ignore system encoding, which will probably be wrong on Windows

and use io.open for Python 2 compatibility