### PR TITLE
Make main entrypoint + option for selecting extensions

### DIFF
--- a/pytest_check_links/__main__.py
+++ b/pytest_check_links/__main__.py
@@ -1,0 +1,27 @@
+"""
+This script will run pytest with our plugin loaded and enabled,
+and with the normal python plugin disabled. This means collection
+of normal tests will be disabled, unless other plugins are set
+to collect further tests. If that is the case, you can disable
+these plugins with the py.test command line option
+"-p no:<plugin-name-here>".
+"""
+import sys
+
+
+def main(args=None):
+    import pytest
+
+    if args is None:
+        args = sys.argv[1:]
+
+    return pytest.main(args + [
+        '--check-links'
+    ], [
+        'no:python'
+        '.plugin'
+    ])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pytest_check_links/__main__.py
+++ b/pytest_check_links/__main__.py
@@ -1,5 +1,5 @@
 """
-This script will run pytest with our plugin loaded and enabled,
+This script will run pytest with our plugin enabled,
 and with the normal python plugin disabled. This means collection
 of normal tests will be disabled, unless other plugins are set
 to collect further tests. If that is the case, you can disable
@@ -16,10 +16,9 @@ def main(args=None):
         args = sys.argv[1:]
 
     return pytest.main(args + [
-        '--check-links'
+        '--check-links',
     ], [
-        'no:python'
-        '.plugin'
+        'no:python',
     ])
 
 

--- a/pytest_check_links/args.py
+++ b/pytest_check_links/args.py
@@ -1,0 +1,16 @@
+import argparse
+
+
+class StoreExtensionsAction(argparse.Action):
+
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(StoreExtensionsAction, self).__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = self.parse_extensions(values)
+        setattr(namespace, self.dest, values)
+
+    def parse_extensions(self, csv):
+        return {'.%s' % ext.lstrip('.') for ext in csv.split(',')}

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -185,15 +185,15 @@ class LinkItem(pytest.Item):
 def extensions_str(extensions):
     if not extensions:
         return ''
-    extensions = [e.lstrip('.') for e in extensions if e]
+    extensions = ['"%s"' % e.lstrip('.') for e in extensions if e]
     if len(extensions) == 1:
         return extensions[0]
     return (", ".join(extensions[:-1]) +
-            ", and %s" % extensions[-1])
+            " and %s" % extensions[-1])
 
 
 def validate_extensions(extensions, warn):
     invalid = set(extensions) - supported_extensions
     if invalid:
         warn("C1", "Unsupported extensions for check-links: %s" %
-            ', '.join([e.lstrip('.') for e in invalid]))
+            extensions_str(invalid))

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -6,18 +6,35 @@ from six.moves.urllib.parse import unquote
 import html5lib
 import pytest
 
+from .args import StoreExtensionsAction
+
 _ENC = 'utf8'
+
+default_extensions = {'.md', '.html', '.ipynb'}
+supported_extensions = {'.md', '.html', '.ipynb'}
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption('--check-links', action='store_true',
         help="Check links for validity")
+    group.addoption('--links-ext', action=StoreExtensionsAction,
+        default=default_extensions,
+        help="Which file extensions to check links for, "
+             "as a comma-separated list of values. Supported "
+             "extensions are: %s." %
+                extensions_str(supported_extensions))
+
+
+def pytest_configure(config):
+    if config.option.links_ext:
+        validate_extensions(config.option.links_ext, config.warn)
 
 
 def pytest_collect_file(path, parent):
     config = parent.config
     if config.option.check_links:
-        if path.ext.lower() in {'.md', '.html', '.ipynb'}:
+        if path.ext.lower() in config.option.links_ext:
             return CheckLinks(path, parent)
 
 
@@ -163,3 +180,20 @@ class LinkItem(pytest.Item):
             target_path = self.fspath.dirpath().join(url_path)
             if not target_path.exists():
                 raise BrokenLinkError(self.target, "No such file: %s" % target_path)
+
+
+def extensions_str(extensions):
+    if not extensions:
+        return ''
+    extensions = [e.lstrip('.') for e in extensions if e]
+    if len(extensions) == 1:
+        return extensions[0]
+    return (", ".join(extensions[:-1]) +
+            ", and %s" % extensions[-1])
+
+
+def validate_extensions(extensions, warn):
+    invalid = set(extensions) - supported_extensions
+    if invalid:
+        warn("C1", "Unsupported extensions for check-links: %s" %
+            ', '.join([e.lstrip('.') for e in invalid]))

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages =
 pytest11 =
     check-links = pytest_check_links.plugin
 console_scripts =
-    pytest_check_links = pytest_check_links.__main__:main
+    pytest-check-links = pytest_check_links.__main__:main
 
 [pep8]
 ignore=E128

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,9 @@ packages =
 [entry_points]
 pytest11 =
     check-links = pytest_check_links.plugin
+
+[pep8]
+ignore=E128
+
+[flake8]
+ignore=E128

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ packages =
 [entry_points]
 pytest11 =
     check-links = pytest_check_links.plugin
+console_scripts =
+    pytest_check_links = pytest_check_links.__main__:main
 
 [pep8]
 ignore=E128

--- a/test/markdown.md
+++ b/test/markdown.md
@@ -1,0 +1,23 @@
+# Markdown file
+
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a reference-style link][Arbitrary case-insensitive reference text]
+
+[I'm a relative reference to a repository file](../README.md)
+
+[You can use numbers for reference-style link definitions][1]
+
+Or leave it empty and use the [link text itself].
+
+URLs and URLs in angle brackets will automatically get turned into links.
+http://www.example.com or <http://www.example.com> and sometimes
+example.com (but not on Github, for example).
+
+Some text to show that the reference links can follow later.
+
+[arbitrary case-insensitive reference text]: https://www.mozilla.org
+[1]: http://slashdot.org
+[link text itself]: http://www.reddit.com


### PR DESCRIPTION
 - Adds a main entry point, which will run pytest with our plugin loaded and enabled, and
without python collection.
 - Adds option `--links-ext` for which extensions (md, ipynb, html) to check the links of.