### PR TITLE
Add rst handling

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -186,8 +186,15 @@ class LinkItem(pytest.Item):
                 url = url.split('#')[0]
 
             url_path = unquote(url).replace('/', os.path.sep)
-            target_path = self.fspath.dirpath().join(url_path)
-            if not target_path.exists():
+            exists = False
+            for ext in supported_extensions:
+                rel_path = url_path.replace('.html', ext)
+                target_path = self.fspath.dirpath().join(rel_path)
+                if target_path.exists():
+                    exists = True
+                    break
+            if not exists:
+                target_path = self.fspath.dirpath().join(url_path)
                 raise BrokenLinkError(self.target, "No such file: %s" % target_path)
 
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -186,15 +186,16 @@ class LinkItem(pytest.Item):
                 url = url.split('#')[0]
 
             url_path = unquote(url).replace('/', os.path.sep)
+            dirpath = self.fspath.dirpath()
             exists = False
             for ext in supported_extensions:
                 rel_path = url_path.replace('.html', ext)
-                target_path = self.fspath.dirpath().join(rel_path)
+                target_path = dirpath.join(rel_path)
                 if target_path.exists():
                     exists = True
                     break
             if not exists:
-                target_path = self.fspath.dirpath().join(url_path)
+                target_path = dirpath.join(url_path)
                 raise BrokenLinkError(self.target, "No such file: %s" % target_path)
 
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -1,3 +1,4 @@
+from docutils.core import publish_parts
 import io
 import os
 from six.moves.urllib.request import urlopen, Request
@@ -10,8 +11,8 @@ from .args import StoreExtensionsAction
 
 _ENC = 'utf8'
 
-default_extensions = {'.md', '.html', '.ipynb'}
-supported_extensions = {'.md', '.html', '.ipynb'}
+default_extensions = {'.md', '.rst', '.html', '.ipynb'}
+supported_extensions = {'.md', '.rst', '.html', '.ipynb'}
 
 
 def pytest_addoption(parser):
@@ -44,7 +45,7 @@ class CheckLinks(pytest.File):
         """Return HTML from an HTML file"""
         with io.open(str(self.fspath), encoding=_ENC) as f:
             return f.read()
-    
+
     def _html_from_markdown(self):
         """Return HTML from a markdown file"""
         # FIXME: use commonmark or a pluggable engine
@@ -52,7 +53,13 @@ class CheckLinks(pytest.File):
         with io.open(str(self.fspath), encoding=_ENC) as f:
             markdown = f.read()
         return markdown2html(markdown)
-    
+
+    def _html_from_rst(self):
+        """Return HTML from an rst file"""
+        with io.open(str(self.fspath), encoding=_ENC) as f:
+            rst = f.read()
+        return publish_parts(rst, writer_name='html')['html_body']
+
     def _items_from_notebook(self):
         """Yield LinkItems from a notebook"""
         import nbformat
@@ -62,7 +69,7 @@ class CheckLinks(pytest.File):
         for cell_num, cell in enumerate(nb.cells):
             if cell.cell_type != 'markdown':
                 continue
-            
+
             html = markdown2html(cell.source)
             basename = 'Cell %i' % cell_num
             for item in links_in_html(basename, self, html):
@@ -79,6 +86,8 @@ class CheckLinks(pytest.File):
             html = self._html_from_html()
         elif path.ext == '.md':
             html = self._html_from_markdown()
+        elif path.ext == '.rst':
+            html = self._html_from_rst()
 
         for item in links_in_html(path, self, html):
             yield item
@@ -97,7 +106,7 @@ class BrokenLinkError(Exception):
 
 def links_in_html(base_name, parent, html):
     """Yield LinkItems from a markdown cell
-    
+
     Parsed HTML with html5lib, yielding LinkItems for testing.
     """
     parsed = html5lib.parse(html, namespaceHTMLElements=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ html5lib
 six
 nbformat
 nbconvert
+docutils

--- a/test/rst.rst
+++ b/test/rst.rst
@@ -1,5 +1,5 @@
-Markdown file
-=============
+Restructured Text file
+======================
 
 `I’m an inline-style link <https://www.google.com>`__
 

--- a/test/rst.rst
+++ b/test/rst.rst
@@ -1,0 +1,22 @@
+Markdown file
+=============
+
+`I’m an inline-style link <https://www.google.com>`__
+
+`I’m an inline-style link with title <https://www.google.com>`__
+
+`I’m a reference-style link <https://www.mozilla.org>`__
+
+`I’m a relative reference to a repository file <../README.md>`__
+
+`You can use numbers for reference-style link
+definitions <http://slashdot.org>`__
+
+Or leave it empty and use the `link text
+itself <http://www.reddit.com>`__.
+
+URLs and URLs in angle brackets will automatically get turned into
+links. http://www.example.com or http://www.example.com and sometimes
+example.com (but not on Github, for example).
+
+Some text to show that the reference links can follow later.

--- a/test/rst.rst
+++ b/test/rst.rst
@@ -1,4 +1,4 @@
-Restructured Text file
+reStructuredText file
 ======================
 
 `I’m an inline-style link <https://www.google.com>`__


### PR DESCRIPTION
We switched from `md` to `rst` in JupyterLab and we were getting some link [rot](https://github.com/jupyterlab/jupyterlab/pull/4988#issuecomment-408580032).

Also allows for relative links to supported file extensions.