### PR TITLE
Use warnings.warn.

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -1,5 +1,6 @@
 import io
 import os
+import warnings
 from six.moves.urllib.request import urlopen, Request
 from six.moves.urllib.parse import unquote
 
@@ -28,7 +29,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     if config.option.links_ext:
-        validate_extensions(config.option.links_ext, config.warn)
+        validate_extensions(config.option.links_ext)
 
 
 def pytest_collect_file(path, parent):
@@ -192,8 +193,8 @@ def extensions_str(extensions):
             " and %s" % extensions[-1])
 
 
-def validate_extensions(extensions, warn):
+def validate_extensions(extensions):
     invalid = set(extensions) - supported_extensions
     if invalid:
-        warn("C1", "Unsupported extensions for check-links: %s" %
+        warnings.warn("C1", "Unsupported extensions for check-links: %s" %
             extensions_str(invalid))


### PR DESCRIPTION
pytest 4.1 (released a couple of days ago) removed `Config.warn` in favor of `warnings.warn`.
https://github.com/pytest-dev/pytest/pull/4542

This makes the corresponding change here.