### PR TITLE
Merge pull request #7 from blink1073/allow-repo-token

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -169,7 +169,7 @@ class LinkItem(pytest.Item):
 
         https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
         """
-        if self.retry_attempts < 3 and 'Retry-After' in obj.headers:
+        if self.retry_attempts < 3:
             try:
                 sleep_time = int(obj.headers['Retry-After'])
             except ValueError:


### PR DESCRIPTION
If the server gives back a `Retry-After` [header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37) in an error response, honor that header.

This is especially useful if the same server is getting hit multiple times in a test, e.g. lots of links to Github.com.

Tested locally against a markdown file with 65 Github links.

cf https://github.com/jupyterlab/jupyterlab/issues/8068